### PR TITLE
Fix code generator to not use %?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.dSYM/
 src/libhttp/codegen/codegen
 src/libhttp/generated/
 build/

--- a/src/libhttp/codegen/status.rs
+++ b/src/libhttp/codegen/status.rs
@@ -219,7 +219,7 @@ impl Status {
     for &entry in entries.iter() {
         match entry {
             Left(heading) => out.write_str(fmt!("\n            // %s\n", heading)),
-            Right(status) => out.write_str(fmt!("            (%?, \"%s\")%s => %s,\n",
+            Right(status) => out.write_str(fmt!("            (%u, \"%s\")%s => %s,\n",
                                                 status.code,
                                                 status.reason.to_ascii_lower(),
                                                 status.reason_padding_spaces(),


### PR DESCRIPTION
The status codes were being emitted with %?. Not only is this a bad idea
in general, but a change today made it start printing out the integral
type suffixes, so 200 became 200u. Unfortunately, the arg that it's
matching against is a u16, not a uint, so this caused a type conflict.
Using %u is not only safe, but avoids the conflict.

Also add *.dSYM/ to the .gitignore.
