### PR TITLE
Update for language changes

### DIFF
--- a/src/examples/client/client.rs
+++ b/src/examples/client/client.rs
@@ -25,7 +25,7 @@ fn main() {
     println("First 1024 bytes of response:");
     let mut buf = [0, ..1024];
     match response.read(buf) {
-        Some(len) => printfln!("%?", str::from_bytes(buf.slice_to(len))),
+        Some(len) => printfln!("%?", str::from_utf8(buf.slice_to(len))),
         None => println("uh oh, got None :-("),
     }
     // TODO: read it *all*, correctly

--- a/src/libhttp/buffer.rs
+++ b/src/libhttp/buffer.rs
@@ -1,6 +1,6 @@
 /// Memory buffers for the benefit of `std::rt::io::net` which has slow read/write.
 
-use std::rt::io::{Reader, Writer, Stream};
+use std::rt::io::{Reader, Writer};
 use std::rt::io::net::tcp::TcpStream;
 use std::cmp::min;
 use std::ptr;
@@ -46,8 +46,6 @@ impl<T: Reader + Writer /*Stream*/> BufferedStream<T> {
         }
     }
 }
-
-impl<T: Stream> Stream for BufferedStream<T>;
 
 impl<T: Reader> BufferedStream<T> {
     /// Poke a single byte back so it will be read next. For this to make sense, you must have just

--- a/src/libhttp/headers/test_utils.rs
+++ b/src/libhttp/headers/test_utils.rs
@@ -13,7 +13,7 @@ pub fn from_stream_with_str<T: HeaderConvertible>(s: &str) -> Option<T> {
 pub fn to_stream_into_str<T: HeaderConvertible>(v: &T) -> ~str {
     let mut writer = MemWriter::new();
     v.to_stream(&mut writer);
-    str::from_bytes(writer.buf)
+    str::from_utf8(writer.buf)
 }
 
 // Verify that a value cannot be successfully interpreted as a header value of the specified type.

--- a/src/libhttp/memstream.rs
+++ b/src/libhttp/memstream.rs
@@ -1,6 +1,6 @@
 /// TODO: submit upstream
 
-use std::rt::io::{Reader, Writer, Seek, SeekStyle, Stream};
+use std::rt::io::{Reader, Writer, Seek, SeekStyle};
 use std::rt::io::mem::{MemReader, MemWriter};
 
 /// Writes to an owned, growable byte vector but also implements read with fail-on-call methods.
@@ -29,8 +29,6 @@ impl Reader for MemWriterFakeStream {
     }
 }
 
-impl Stream for MemWriterFakeStream;
-
 /// Reads from an owned byte vector, but also implements write with fail-on-call methods.
 pub struct MemReaderFakeStream(MemReader);
 
@@ -56,8 +54,6 @@ impl Writer for MemReaderFakeStream {
         fail!("Uh oh, you didn't aught to call MemReaderFakeStream.flush()!")
     }
 }
-
-impl Stream for MemReaderFakeStream;
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
- Rename `str::from_bytes` -> `str::from_utf8`
- Remove `impl Stream ...` which is now supported by std
