### PR TITLE
Update for upstream changes

### DIFF
--- a/src/libhttp/headers/connection.rs
+++ b/src/libhttp/headers/connection.rs
@@ -23,7 +23,7 @@ impl ToStr for Connection {
     }
 }
 
-impl super::CommaListHeaderConvertible for Connection;
+impl super::CommaListHeaderConvertible for Connection {}
 
 impl super::HeaderConvertible for Connection {
     fn from_stream<T: Reader>(reader: &mut super::HeaderValueByteIterator<T>)

--- a/src/libhttp/headers/mod.rs
+++ b/src/libhttp/headers/mod.rs
@@ -612,7 +612,7 @@ impl HeaderConvertible for Url {
     }
 }
 
-impl CommaListHeaderConvertible for Method;
+impl CommaListHeaderConvertible for Method {}
 
 impl HeaderConvertible for Method {
     fn from_stream<T: Reader>(reader: &mut HeaderValueByteIterator<T>) -> Option<Method> {

--- a/src/libhttp/headers/transfer_encoding.rs
+++ b/src/libhttp/headers/transfer_encoding.rs
@@ -16,7 +16,7 @@ pub enum TransferCoding {
     TransferExtension(~str, ~[(~str, ~str)]),
 }
 
-impl super::CommaListHeaderConvertible for TransferCoding;
+impl super::CommaListHeaderConvertible for TransferCoding {}
 
 impl super::HeaderConvertible for TransferCoding {
     fn from_stream<T: Reader>(reader: &mut super::HeaderValueByteIterator<T>)


### PR DESCRIPTION
Also note that `extra::url::Url` is unusable for now since it is private. (mozilla/rust#9526)
