### PR TITLE
Only build lib by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,4 +54,4 @@ clean:
 	rm -rf src/libhttp/generated/ src/libhttp/codegen/codegen
 	rm -rf build/
 
-.PHONY: libhttp examples clean check
+.PHONY: all libhttp examples clean check


### PR DESCRIPTION
The current Makefile builds examples by default, this allows "make" to only build the library while "make all" will build both the library and examples.
