### PR TITLE
Parse modification time to avoid ugliness

### DIFF
--- a/src/examples/server/apache_fake/main.rs
+++ b/src/examples/server/apache_fake/main.rs
@@ -5,6 +5,7 @@
 extern mod extra;
 extern mod http;
 
+use std::option::IntoOption;
 use std::rt::io::net::ip::{SocketAddr, Ipv4Addr};
 use std::rt::io::Writer;
 use extra::time;
@@ -23,21 +24,9 @@ impl Server for ApacheFakeServer {
     fn handle_request(&self, _r: &Request, w: &mut ResponseWriter) {
         w.headers.date = Some(time::now_utc());
         w.headers.server = Some(~"Apache/2.2.22 (Ubuntu)");
-        //w.headers.last_modified = Some(~"Thu, 05 May 2011 11:46:42 GMT");
-        w.headers.last_modified = Some(time::Tm {
-            tm_sec: 42, // seconds after the minute ~[0-60]
-            tm_min: 46, // minutes after the hour ~[0-59]
-            tm_hour: 11, // hours after midnight ~[0-23]
-            tm_mday: 5, // days of the month ~[1-31]
-            tm_mon: 4, // months since January ~[0-11]
-            tm_year: 111, // years since 1900
-            tm_wday: 4, // days since Sunday ~[0-6]
-            tm_yday: 0, // days since January 1 ~[0-365]
-            tm_isdst: 0, // Daylight Savings Time flag
-            tm_gmtoff: 0, // offset from UTC in seconds
-            tm_zone: ~"GMT", // timezone abbreviation
-            tm_nsec: 0, // nanoseconds
-        });
+        w.headers.last_modified =
+            time::strptime("Thu, 05 May 2011 11:46:42 GMT",
+                           "%a, %d %b %Y %H:%M:%S %Z").into_option();
         w.headers.etag = Some(headers::etag::EntityTag {
                                 weak: false,
                                 opaque_tag: ~"501b29-b1-4a285ed47404a" });


### PR DESCRIPTION
Should the time be cached in ApacheFakeServer to avoid paying the parse overhead per request?
