### PR TITLE
Modifications to allow rust to work with the latest version of rust-master

### DIFF
--- a/src/http/buffer.rs
+++ b/src/http/buffer.rs
@@ -113,11 +113,6 @@ impl<T: Reader> Reader for BufferedStream<T> {
         self.read_pos += size;
         Some(size)
     }
-
-    /// Return whether the Reader has reached the end of the stream AND exhausted its buffer.
-    fn eof(&mut self) -> bool {
-        self.read_pos == self.read_max && self.wrapped.eof()
-    }
 }
 
 impl<T: Writer> Writer for BufferedStream<T> {

--- a/src/http/client/response.rs
+++ b/src/http/client/response.rs
@@ -146,8 +146,4 @@ impl<S: Stream> Reader for ResponseReader<S> {
     fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
         self.stream.read(buf)
     }
-
-    fn eof(&mut self) -> bool {
-        self.stream.eof()
-    }
 }

--- a/src/http/headers/mod.rs
+++ b/src/http/headers/mod.rs
@@ -736,6 +736,7 @@ impl HeaderConvertible for Tm {
 mod test {
     use extra::time::Tm;
     use headers::test_utils::{from_stream_with_str, to_stream_into_str};
+    use super::HeaderConvertible;
 
     #[test]
     fn test_from_stream_str() {

--- a/src/http/headers/test_utils.rs
+++ b/src/http/headers/test_utils.rs
@@ -1,12 +1,11 @@
-use std::io::Decorator;
 use std::io::mem::{MemReader, MemWriter};
 use std::str;
 use headers::{HeaderConvertible, HeaderValueByteIterator};
 
 pub fn from_stream_with_str<T: HeaderConvertible>(s: &str) -> Option<T> {
-    let bytes = s.as_bytes();
-    let mut reader = MemReader::new(bytes.into_owned());
-    reader.inner_mut_ref().push_all(bytes!("\r\n/"));
+    let mut bytes = s.as_bytes().into_owned();
+    bytes.push_all(bytes!("\r\n/"));
+    let mut reader = MemReader::new(bytes);
     let mut iter = HeaderValueByteIterator::new(&mut reader);
     HeaderConvertible::from_stream(&mut iter)
 }
@@ -14,7 +13,7 @@ pub fn from_stream_with_str<T: HeaderConvertible>(s: &str) -> Option<T> {
 pub fn to_stream_into_str<T: HeaderConvertible>(v: &T) -> ~str {
     let mut writer = MemWriter::new();
     v.to_stream(&mut writer);
-    str::from_utf8_owned(writer.inner_ref().to_owned())
+    str::from_utf8_owned(writer.get_ref().to_owned())
 }
 
 // Verify that a value cannot be successfully interpreted as a header value of the specified type.

--- a/src/http/memstream.rs
+++ b/src/http/memstream.rs
@@ -38,9 +38,6 @@ impl Reader for MemWriterFakeStream {
     fn read(&mut self, _buf: &mut [u8]) -> Option<uint> {
         fail!("Uh oh, you didn't aught to call MemWriterFakeStream.read()!")
     }
-    fn eof(&mut self) -> bool {
-        fail!("Uh oh, you didn't aught to call MemWriterFakeStream.eof()!")
-    }
 }
 
 /// Reads from an owned byte vector, but also implements write with fail-on-call methods.
@@ -54,11 +51,6 @@ impl Reader for MemReaderFakeStream {
     fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
         let &MemReaderFakeStream(ref mut s) = self;
         s.read(buf)
-    }
-
-    fn eof(&mut self) -> bool {
-        let &MemReaderFakeStream(ref mut s) = self;
-        s.eof()
     }
 }
 
@@ -114,8 +106,6 @@ mod test {
         assert_eq!(buf, [1, 2, 3, 4]);
         assert_eq!(reader.read(buf), Some(3));
         assert_eq!(buf.slice(0, 3), [5, 6, 7]);
-        assert!(reader.eof());
         assert_eq!(reader.read(buf), None);
-        assert!(reader.eof());
     }
 }

--- a/src/http/server/mod.rs
+++ b/src/http/server/mod.rs
@@ -1,7 +1,7 @@
 extern mod extra;
 
 use std::comm::SharedChan;
-use std::io::{Listener, Acceptor, Writer};
+use std::io::{Listener, Acceptor};
 use std::io::net::ip::SocketAddr;
 use std::io::io_error;
 use extra::time::precise_time_ns;

--- a/src/http/server/request.rs
+++ b/src/http/server/request.rs
@@ -164,9 +164,6 @@ fn test_read_request_line() {
             let mut stream = BufferedStream::new(
                 MemReaderFakeStream::new($value.as_bytes().to_owned()));
             assert_eq!(RequestBuffer::new(&mut stream).read_request_line(), expected);
-            if expected.is_ok() {
-                assert!(stream.eof());
-            }
         }}
     )
 


### PR DESCRIPTION
Changes were:
- `std::io::Decorator` trait is now gone (`test_utils.rs`, lines 6-10 is the only big change)
- `io::Reader` no longer implements `eof()` - it doesn't seem like we were using it too much anyway.
