### PR TITLE
Rust update: DeepClone was removed

### DIFF
--- a/src/http/headers/connection.rs
+++ b/src/http/headers/connection.rs
@@ -10,7 +10,7 @@ use headers::serialization_utils::normalise_header_name;
 
 /// A value for the Connection header. Note that should it be a ``Token``, the string is in
 /// normalised header case (e.g. "Keep-Alive").
-#[deriving(Clone, DeepClone, Eq)]
+#[deriving(Clone, Eq)]
 pub enum Connection {
     Token(~str),
     Close,

--- a/src/http/headers/mod.rs
+++ b/src/http/headers/mod.rs
@@ -62,7 +62,7 @@ pub mod transfer_encoding;
 
 pub type DeltaSeconds = u64;
 
-#[deriving(Clone, DeepClone, Eq)]
+#[deriving(Clone, Eq)]
 pub enum ConsumeCommaLWSResult {
     CommaConsumed,
     EndOfValue,


### PR DESCRIPTION
`DeepClone` was removed in mozilla/rust#12706.
