### PR TITLE
Logging macros are moved out to the separate crate `log`.

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -11,8 +11,10 @@
 //#[deny(missing_doc)];
 
 #[feature(macro_rules)];
+#[feature(phase)];
 #[macro_escape];
 
+#[phase(syntax, link)] extern crate log;
 extern crate extra;
 extern crate time;
 extern crate collections;


### PR DESCRIPTION
I added a declaration to introduce logging macros, because they are extracted to `liblog` crate due to  mozilla/rust#12791.
