### PR TITLE
SSL client support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ doc/http/
 doc/src/http/
 lib/
 .rust/
+Makefile

--- a/.hgignore
+++ b/.hgignore
@@ -8,3 +8,4 @@
 ^doc/src/http/
 ^lib/
 ^.rust/
+^Makefile$

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,14 @@ before_install:
   - sudo apt-get update
 install:
   - sudo apt-get install rust-nightly
+  - git clone https://github.com/sfackler/rust-openssl.git
+  - cd rust-openssl
+  - ./configure
+  - make
+  - cd ..
+  - mv rust-openssl ../
 script:
-  - make check
-  - make docs
+  - ./configure
+  - make all check docs
 after_script:
   - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,9 @@
+SSL_LIB ?= %SSL_LIB%
+SSL_CFG ?= %SSL_CFG%
 RUSTC ?= rustc
 RUSTDOC ?= rustdoc
 RUSTPKG ?= rustpkg
-RUSTFLAGS ?= -O
+RUSTFLAGS ?= -O -L $(SSL_LIB) $(SSL_CFG)
 RUST_REPOSITORY ?= ../rust
 RUST_CTAGS ?= $(RUST_REPOSITORY)/src/etc/ctags.rust
 VERSION=0.1-pre
@@ -12,7 +14,7 @@ codegen_files=\
 	        src/codegen/read_method.rs \
 	        src/codegen/status.rs \
 
-libhttp_so=build/libhttp-9296ff29-0.1-pre.so
+libhttp_so=build/.libhttp.timestamp
 http_files=\
 		      src/http/lib.rs \
 		      src/http/buffer.rs \
@@ -28,9 +30,20 @@ http_files=\
 
 http: $(libhttp_so)
 
-$(libhttp_so): $(http_files)
+Makefile: configure Makefile.in
+	@echo "configure or Makefile.in changed, regenerating Makefile"
+	@DOING_RECONFIGURE=1 SSL_LIB="$(SSL_LIB)" SSL_CFG="$(SSL_CFG)" ./configure
+	@echo
+	@echo ======================
+	@echo Please run make again!
+	@echo ======================
+	@echo
+	@exit 1
+
+$(libhttp_so): Makefile $(http_files)
 	mkdir -p build/
 	$(RUSTC) $(RUSTFLAGS) src/http/lib.rs --out-dir=build
+	@touch build/.libhttp.timestamp
 
 all: http examples docs
 

--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,22 @@ At present, all of the example servers serve to http://127.0.0.1:8001/.
 Don't expect everything to work well. The server claims HTTP/1.1, but is not
 in any way compliant yet.
 
+SSL support
+-----------
+
+rust-http can be compiled with or without SSL support.
+
+To compile with SSL support, drop rust-openssl_ in a sibling directory of
+rust-http (i.e. ``../rust-openssl`` from this file) and run its ``configure``
+and ``make``. rust-http's ``configure`` will then automatically detect it and
+you will get SSL support enabled.
+
+To compile rust-http without SSL support, just don’t put rust-openssl_ where it
+can find it. You'll then get an ``IoError { kind: InvalidInput, .. }`` if you
+try to make an SSL request (e.g. HTTPS).
+
+.. _rust-openssl: https://github.com/sfackler/rust-openssl
+
 Roadmap
 -------
 

--- a/configure
+++ b/configure
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+if [ "$1" = --help ]; then
+	echo "Usage: ./configure"
+	echo
+	echo "Sorry, no command line arguments or anything; it's too hard."
+	echo
+	echo "You can, however, use environment variables:"
+	echo
+	echo "- WITH_OPENSSL=/path/to/rust-openssl"
+	echo "- WITH_NSS=/path/to/rust-nss"
+	echo "- WITHOUT_SSL=1"
+	echo
+	echo "If you specify nothing, it will try ../rust-openssl and ../rust-nss."
+	exit
+fi
+
+if [ -n "$DOING_RECONFIGURE" ]; then
+	echo configure: reapplying existing configuration
+	# Inherit variables
+elif [ -n "$WITH_OPENSSL" ]; then
+	echo configure: OpenSSL specified, using it.
+	SSL_LIB="$WITH_OPENSSL/build"
+	SSL_CFG="--cfg openssl"
+elif [ -n "$WITH_NSS" ]; then
+	echo configure: NSS specified, using it.
+	SSL_LIB="$WITH_NSS/build"
+	SSL_CFG="--cfg nss"
+elif [ -n "$WITHOUT_SSL" ]; then
+	echo configure: disabling SSL support
+	SSL_LIB=
+	SSL_CFG=
+elif [ -d ../rust-openssl ]; then
+	echo configure: no SSL library selected but OpenSSL found at ../rust-openssl, using it.
+	SSL_LIB=../rust-openssl/build
+	SSL_CFG="--cfg openssl"
+elif [ -d ../rust-nss ]; then
+	echo configure: no SSL library selected but NSS found at ../rust-nss, using it.
+	SSL_LIB=../rust-nss/build
+	SSL_CFG="--cfg nss"
+else
+	echo configure: no SSL library selected or found
+	echo configure: you will not be able to access HTTPS URLs
+	echo configure: check the README for instructions on enabling HTTPS
+	SSL_LIB=
+	SSL_CFG=
+fi
+
+echo configure: writing Makefile
+sed -e "s|%SSL_LIB%|$SSL_LIB|" \
+	-e "s|%SSL_CFG%|$SSL_CFG|" \
+	Makefile.in > Makefile
+echo configure: done!

--- a/src/examples/client/main.rs
+++ b/src/examples/client/main.rs
@@ -23,8 +23,8 @@ fn main() {
 }
 
 fn make_and_print_request(url: ~str) {
-    let request = RequestWriter::<TcpStream>::new(Get, from_str(url).expect("Invalid URL :-("))
-                               .unwrap();
+    let request: RequestWriter = RequestWriter::new(Get, from_str(url).expect("Invalid URL :-("))
+                                              .unwrap();
 
     println!("[33;1mRequest[0m");
     println!("[33;1m=======[0m");
@@ -51,6 +51,9 @@ fn make_and_print_request(url: ~str) {
         println!(" - {}: {}", header.header_name(), header.header_value());
     }
     println!("[1mBody:[0m");
-    let body = response.read_to_end().unwrap();
+    let body = match response.read_to_end() {
+        Ok(body) => body,
+        Err(err) => fail!("Reading response failed: {}", err),
+    };
     println(str::from_utf8(body).expect("Uh oh, response wasn't UTF-8"));
 }

--- a/src/http/client/mod.rs
+++ b/src/http/client/mod.rs
@@ -17,6 +17,8 @@ possible, but it's not elegant convenient yet. (Most notably, no transfer-encodi
 
 pub use self::request::RequestWriter;
 pub use self::response::ResponseReader;
+pub use self::sslclients::NetworkStream;
 
 pub mod request;
 pub mod response;
+mod sslclients;

--- a/src/http/client/request.rs
+++ b/src/http/client/request.rs
@@ -35,6 +35,7 @@ let response = match request.read_response() {
 ```
 
 */
+
 use url;
 use url::Url;
 use method::Method;
@@ -65,8 +66,9 @@ use client::response::ResponseReader;
     }
 }*/
 
-pub struct RequestWriter<S> {
-    // The place to write to (typically a TCP stream, io::net::tcp::TcpStream)
+pub struct RequestWriter<S = super::NetworkStream> {
+    // The place to write to (typically a network stream, which is
+    // io::net::tcp::TcpStream or an SSL wrapper around that)
     stream: Option<BufferedStream<S>>,
     headers_written: bool,
 
@@ -86,6 +88,9 @@ pub struct RequestWriter<S> {
 
     /// The URL being requested.
     pub url: Url,
+
+    /// Should we use SSL?
+    use_ssl: bool,
 }
 
 /// Low-level HTTP request writing support
@@ -94,9 +99,13 @@ pub struct RequestWriter<S> {
 /// take place until writing is completed.
 ///
 /// At present, this only supports making one request per connection.
-impl<S: Reader + Writer> RequestWriter<S> {
+impl<S: Reader + Writer = super::NetworkStream> RequestWriter<S> {
     /// Create a `RequestWriter` writing to the specified location
     pub fn new(method: Method, url: Url) -> IoResult<RequestWriter<S>> {
+        RequestWriter::new_request(method, url, false, true)
+    }
+    
+    pub fn new_request(method: Method, url: Url, use_ssl: bool, auto_detect_ssl: bool) -> IoResult<RequestWriter<S>> {
         let host = match url.port {
             None => Host {
                 name: url.host.to_owned(),
@@ -125,10 +134,12 @@ impl<S: Reader + Writer> RequestWriter<S> {
             // TODO: Error handling
             let addr = addr.unwrap();
 
-            let port = url.port.clone().unwrap_or(~"80");
-            let port = from_str(port);
-            // TODO: Error handling
-            let port = port.unwrap();
+            // Default to 80, using the port specified or 443 if the protocol is HTTPS.
+            let port = match url.port {
+                Some(ref p) => from_str(*p).expect("You didn’t aught to give a bad port!"),
+                // FIXME: case insensitivity?
+                None => if url.scheme.as_slice() == "https" { 443 } else { 80 },
+            };
 
             Ok(SocketAddr {
                 ip: addr,
@@ -143,13 +154,20 @@ impl<S: Reader + Writer> RequestWriter<S> {
             headers: ~HeaderCollection::new(),
             method: method,
             url: url,
+            use_ssl: use_ssl,
         };
+
+        if auto_detect_ssl {
+            // FIXME: case insensitivity?
+            request.use_ssl = request.url.scheme.as_slice() == "https";
+        }
+
         request.headers.host = Some(host);
         Ok(request)
     }
 }
 
-impl<S: Connecter + Reader + Writer> RequestWriter<S> {
+impl<S: Connecter + Reader + Writer = super::NetworkStream> RequestWriter<S> {
 
     /// Connect to the remote host if not already connected.
     pub fn try_connect(&mut self) -> IoResult<()> {
@@ -169,7 +187,7 @@ impl<S: Connecter + Reader + Writer> RequestWriter<S> {
 
         self.stream = match self.remote_addr {
             Some(addr) => {
-                let stream = try!(Connecter::connect(addr));
+                let stream = try!(Connecter::connect(addr, self.url.host, self.use_ssl));
                 Some(BufferedStream::new(stream))
             },
             None => fail!("connect() called before remote_addr was set"),
@@ -235,7 +253,7 @@ impl<S: Connecter + Reader + Writer> RequestWriter<S> {
 }
 
 /// Write the request body. Note that any calls to `write()` will cause the headers to be sent.
-impl<S: Reader + Writer + Connecter> Writer for RequestWriter<S> {
+impl<S: Reader + Writer + Connecter = super::NetworkStream> Writer for RequestWriter<S> {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         if !self.headers_written {
             try!(self.write_headers());

--- a/src/http/client/sslclients/mod.rs
+++ b/src/http/client/sslclients/mod.rs
@@ -1,0 +1,16 @@
+//! SSL client support.
+//!
+//! Which particular library is used depends upon the configuration used at
+//! compile time; at present it can only be OpenSSL (`--cfg openssl`); without
+//! that, you won't be able to use SSL (an attempt to make an HTTPS connection
+//! will return an error).
+
+#[cfg(openssl)]
+pub use self::openssl::NetworkStream;
+#[cfg(not(openssl))]
+pub use self::none::NetworkStream;
+
+#[cfg(openssl)]
+mod openssl;
+#[cfg(not(openssl))]
+mod none;

--- a/src/http/client/sslclients/none.rs
+++ b/src/http/client/sslclients/none.rs
@@ -1,0 +1,53 @@
+//! No SSL support (neither OpenSSL nor NSS were compiled in).
+
+use std::io::net::ip::SocketAddr;
+use std::io::net::tcp::TcpStream;
+use std::io::{IoResult, IoError, InvalidInput};
+use connecter::Connecter;
+
+/// A TCP stream, plain text and with no SSL support.
+///
+/// This build was made *without* SSL support; if you attempt to make an SSL
+/// connection you will receive an `IoError` of the `InvalidInput` kind.
+///
+/// (To build with SSL support, use ``--cfg openssl`` or ``--cfg nss``.)
+pub enum NetworkStream {
+    priv NormalStream(TcpStream),
+}
+
+impl Connecter for NetworkStream {
+    fn connect(addr: SocketAddr, _host: &str, use_ssl: bool) -> IoResult<NetworkStream> {
+        if use_ssl {
+            Err(IoError {
+                kind: InvalidInput,
+                desc: "http crate was compiled without SSL support",
+                detail: None,
+            })
+        } else {
+            let stream = try!(TcpStream::connect(addr));
+            Ok(NormalStream(stream))
+        }
+    }
+}
+
+impl Reader for NetworkStream {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
+        match *self {
+            NormalStream(ref mut ns) => ns.read(buf),
+        }
+    }
+}
+
+impl Writer for NetworkStream {
+    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+        match *self {
+            NormalStream(ref mut ns) => ns.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        match *self {
+            NormalStream(ref mut ns) => ns.flush(),
+        }
+    }
+}

--- a/src/http/client/sslclients/openssl.rs
+++ b/src/http/client/sslclients/openssl.rs
@@ -1,0 +1,54 @@
+//! SSL support provided by OpenSSL.
+
+extern crate openssl;
+
+use std::io::net::ip::SocketAddr;
+use std::io::net::tcp::TcpStream;
+use std::io::IoResult;
+use self::openssl::ssl::{SslStream, SslContext, Sslv23};
+use connecter::Connecter;
+
+/// A TCP stream, either plain text or SSL.
+///
+/// This build was made with **OpenSSL** providing SSL support.
+pub enum NetworkStream {
+    priv NormalStream(TcpStream),
+    priv SslProtectedStream(SslStream<TcpStream>),
+}
+
+impl Connecter for NetworkStream {
+    fn connect(addr: SocketAddr, _host: &str, use_ssl: bool) -> IoResult<NetworkStream> {
+        let stream = try!(TcpStream::connect(addr));
+        if use_ssl {
+            let ssl_stream = SslStream::new(&SslContext::new(Sslv23), stream);
+            Ok(SslProtectedStream(ssl_stream))
+        } else {
+            Ok(NormalStream(stream))
+        }
+    }
+}
+
+impl Reader for NetworkStream {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
+        match *self {
+            NormalStream(ref mut ns) => ns.read(buf),
+            SslProtectedStream(ref mut ns) => ns.read(buf),
+        }
+    }
+}
+
+impl Writer for NetworkStream {
+    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+        match *self {
+            NormalStream(ref mut ns) => ns.write(buf),
+            SslProtectedStream(ref mut ns) => ns.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        match *self {
+            NormalStream(ref mut ns) => ns.flush(),
+            SslProtectedStream(ref mut ns) => ns.flush(),
+        }
+    }
+}

--- a/src/http/connecter.rs
+++ b/src/http/connecter.rs
@@ -10,11 +10,5 @@ use std::io::net::tcp::TcpStream;
 /// connections in terms of *anything* that can make such a connection rather
 /// than in terms of `TcpStream` only. This is handy for testing and for SSL.
 pub trait Connecter {
-    fn connect(addr: SocketAddr) -> IoResult<Self>;
-}
-
-impl Connecter for TcpStream {
-    fn connect(addr: SocketAddr) -> IoResult<TcpStream> {
-        TcpStream::connect(addr)
-    }
+    fn connect(addr: SocketAddr, host: &str, use_ssl: bool) -> IoResult<Self>;
 }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -10,6 +10,7 @@
 #![deny(non_camel_case_types)]
 //#[deny(missing_doc)];
 
+#![feature(default_type_params)]
 #![feature(macro_rules)]
 #![feature(phase)]
 #![macro_escape]


### PR DESCRIPTION
This supersedes #31. Compared to it,

> This involves significant updates for Rust and rust-http changes, especially the explicit `IoResult` stuff.
> 
> I've restructured it quite a bit to better suit my notions of how it should be done, and also introduced a new `./configure` step before you can `make`, which will detect OpenSSL or NSS (I bet that my NSS detection in `configure` is incorrect).
> 
> The only change in runtime behaviour is that attempting to connect to an HTTPS site when not compiled with SSL support will return an error (of kind `InvalidInput`) rather than silently, confusingly and dangerously (should the server accept it rather than rejecting it) sending plain text.

Actually, the NSS stuff is definitely broken (`_host` vs. `host` in the function). The question that remains is: will [rust-nss](https://github.com/mletterle/rust-nss) be fixed and maintained, or should NSS support be dropped?

cc @mletterle @metajack @brson @wycats @steveklabnik
