### PR TITLE
Follow the latest changes up to 2014-03-23

### DIFF
--- a/src/examples/server/apache_fake/main.rs
+++ b/src/examples/server/apache_fake/main.rs
@@ -7,8 +7,6 @@
 extern crate time;
 extern crate http;
 
-use std::vec::Vec;
-
 use std::io::net::ip::{SocketAddr, Ipv4Addr};
 use std::io::Writer;
 

--- a/src/examples/server/request_uri/main.rs
+++ b/src/examples/server/request_uri/main.rs
@@ -9,8 +9,6 @@
 extern crate time;
 extern crate http;
 
-use std::vec::Vec;
-
 use std::io::net::ip::{SocketAddr, Ipv4Addr};
 use std::io::Writer;
 
@@ -75,7 +73,7 @@ impl Server for RequestUriServer {
             },
             AbsoluteUri(ref url) => {
                 println!("absoluteURI, {}", url.to_str());
-                //path = 
+                //path =
             },
             AbsolutePath(ref url) => {
                 println!("absolute path, {}", url.to_owned());

--- a/src/http/buffer.rs
+++ b/src/http/buffer.rs
@@ -2,7 +2,6 @@
 
 use std::io::{IoResult, Stream};
 use std::cmp::min;
-use std::vec::Vec;
 use std::slice;
 use std::num::ToStrRadix;
 

--- a/src/http/headers/accept_ranges.rs
+++ b/src/http/headers/accept_ranges.rs
@@ -1,6 +1,5 @@
 //! The Accept-Ranges request header, defined in RFC 2616, Section 14.5.
 
-use std::vec::Vec;
 use std::io::IoResult;
 use std::ascii::StrAsciiExt;
 

--- a/src/http/headers/connection.rs
+++ b/src/http/headers/connection.rs
@@ -58,7 +58,6 @@ impl super::HeaderConvertible for Connection {
 
 #[test]
 fn test_connection() {
-    use std::vec::Vec;
     use headers::test_utils::{assert_conversion_correct,
                               assert_interpretation_correct,
                               assert_invalid};

--- a/src/http/headers/content_type.rs
+++ b/src/http/headers/content_type.rs
@@ -1,6 +1,5 @@
 //! The Content-Type entity header, defined in RFC 2616, Section 14.17.
 use headers::serialization_utils::{push_parameters, WriterUtil};
-use std::vec::Vec;
 use std::io::IoResult;
 use std::fmt;
 

--- a/src/http/headers/mod.rs
+++ b/src/http/headers/mod.rs
@@ -5,7 +5,6 @@
 //! unknown headers are stored in a map in the traditional way.
 
 use url::Url;
-use std::vec::Vec;
 use std::io::IoResult;
 use time::{Tm, strptime};
 use rfc2616::{is_token_item, is_separator, CR, LF, SP, HT, COLON};
@@ -872,7 +871,6 @@ macro_rules! headers_mod {
             #[$attr]
 
             #[allow(unused_imports)]
-            use std::vec::Vec;
             use std::io::IoResult;
             use time;
             use collections::treemap::{TreeMap, Entries};

--- a/src/http/headers/serialization_utils.rs
+++ b/src/http/headers/serialization_utils.rs
@@ -1,6 +1,5 @@
 //! Utility functions for assisting with conversion of headers from and to the HTTP text form.
 
-use std::vec::Vec;
 use std::slice;
 use std::ascii::Ascii;
 use std::io::IoResult;

--- a/src/http/headers/transfer_encoding.rs
+++ b/src/http/headers/transfer_encoding.rs
@@ -2,7 +2,6 @@
 //!
 //! Transfer-Encoding       = "Transfer-Encoding" ":" 1#transfer-coding
 
-use std::vec::Vec;
 use std::ascii::StrAsciiExt;
 use std::io::IoResult;
 use headers::serialization_utils::{WriterUtil, push_parameters};


### PR DESCRIPTION
related issues of mozilla/rust:
- mozilla/rust#12772  rename std::vec -> std::slice
- mozilla/rust#13028  rename std::vec_ng -> std::vec
- mozilla/rust@0305ed5d22e4  std: Add Vec to the prelude
- mozilla/rust#12907  std: Rename {push,read}_bytes to {push,read}_exact
