### PR TITLE
HTTP over UDP friendly

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -32,5 +32,6 @@ pub mod rfc2616;
 #[path = "generated/status.rs"]
 pub mod status;  // Getting an error? It's generated; use ``make`` or see the ``Makefile``
 
-
+/// TODO: submit upstream
+#[cfg(test)]
 pub mod memstream;

--- a/src/http/server/mod.rs
+++ b/src/http/server/mod.rs
@@ -60,7 +60,8 @@ pub trait Server: Send + Clone {
                 debug!("accepted connection");
                 loop {  // A keep-alive loop, condition at end
                     let time_spawned = precise_time_ns();
-                    let (request, err_status) = Request::load(&mut stream);
+                    let remote_addr = stream.wrapped.peer_name().ok();
+                    let (request, err_status) = Request::load(&mut stream, remote_addr);
                     let time_request_made = precise_time_ns();
                     let mut response = box ResponseWriter::new(&mut stream, request);
                     let time_response_made = precise_time_ns();

--- a/src/http/server/request.rs
+++ b/src/http/server/request.rs
@@ -201,6 +201,7 @@ fn test_read_request_line() {
 /// An HTTP request sent to the server.
 pub struct Request {
     /// The originating IP address of the request.
+    pub remote_addr: Option<SocketAddr>,
 
     /// The host name and IP address that the request was sent to; this must always be specified for
     /// HTTP/1.1 requests (or the request will be rejected), but for HTTP/1.0 requests the Host
@@ -294,12 +295,13 @@ impl fmt::Show for RequestUri {
 impl Request {
 
     /// Get a response from an open socket.
-    pub fn load<T: Stream>(stream: &mut BufferedStream<T>) -> (Box<Request>, Result<(), status::Status>) {
+    pub fn load<T: Stream>(stream: &mut BufferedStream<T>, remote_addr: Option<SocketAddr>) -> (Box<Request>, Result<(), status::Status>) {
         let mut buffer = RequestBuffer::new(stream);
 
         // Start out with dummy values
         let mut request = box Request {
             headers: box headers::request::HeaderCollection::new(),
+            remote_addr: remote_addr,
             body: String::new(),
             method: Options,
             request_uri: Star,


### PR DESCRIPTION
I'm working on a library in Rust for use with the UPnP discovery protocol SSDP. This uses HTTP-ish over UDP.

No longer requires a specific TcpStream in the BufferedStream so it's possible to use your MemReaderFakeStream.  

FYI - these changes are working here: https://github.com/davbo/rust-ssdp/blob/master/src/lib.rs#L36
