### PR TITLE
Update to remove ~

### DIFF
--- a/src/codegen/main.rs
+++ b/src/codegen/main.rs
@@ -37,11 +37,11 @@ fn main() {
     }
 }
 
-pub fn get_writer(output_dir: &Path, filename: &str) -> ~Writer {
+pub fn get_writer(output_dir: &Path, filename: &str) -> Box<Writer> {
     let mut output_file = output_dir.clone();
     output_file.push(filename);
     match File::open_mode(&output_file, Truncate, Write) {
-        Ok(writer) => ~writer as ~Writer,
+        Ok(writer) => box writer as Box<Writer>,
         Err(e) => fail!("Unable to write file: {}", e.desc),
     }
 }


### PR DESCRIPTION
I hit the following errors when running 'make all':

```
mkdir -p build/
rustc src/codegen/main.rs --out-dir=build
src/codegen/main.rs:40:57: 40:58 error: obsolete syntax: `~` notation for owned pointers
src/codegen/main.rs:40 pub fn get_writer(output_dir: &Path, filename: &str) -> ~Writer {
                                                                               ^
note: use `Box<T>` in `std::owned` instead
src/codegen/main.rs:44:24: 44:30 error: obsolete syntax: `~` notation for owned pointer allocation
src/codegen/main.rs:44         Ok(writer) => ~writer as ~Writer,
                                              ^~~~~~
note: use the `box` operator instead of `~`
src/codegen/main.rs:44:34: 44:35 error: obsolete syntax: `~` notation for owned pointers
src/codegen/main.rs:44         Ok(writer) => ~writer as ~Writer,
                                                        ^
error: aborting due to 3 previous errors
```

I fixed it by updating `src/codegen/main.rs` as the compiler suggested.
