### PR TITLE
`std::os::args()` returns a Vec and ~[T] doesn't implement `FromIterator`

### DIFF
--- a/src/codegen/main.rs
+++ b/src/codegen/main.rs
@@ -19,9 +19,9 @@ fn main() {
             os::set_exit_status(1);
         },
         3 => {
-            let output_dir = Path::new(args[2].as_slice());
+            let output_dir = Path::new(args.get(2).as_slice());
 
-            match args[1].as_slice() {
+            match args.get(1).as_slice() {
                 "read_method.rs" => read_method::generate(&output_dir).unwrap(),
                 "status.rs" => status::generate(&output_dir).unwrap(),
                 s => {
@@ -31,7 +31,7 @@ fn main() {
             }
         },
         _ => {
-            println!("usage: {} [read_method|status].rs <output-dir>", args[0]);
+            println!("usage: {} [read_method|status].rs <output-dir>", args.get(0));
             os::set_exit_status(1);
         }
     }

--- a/src/examples/client/main.rs
+++ b/src/examples/client/main.rs
@@ -13,9 +13,9 @@ fn main() {
     let args = os::args();
     match args.len() {
         0 => unreachable!(),
-        2 => make_and_print_request(args[1]),
+        2 => make_and_print_request(*args.get(1)),
         _ => {
-            println!("Usage: {} URL", args[0]);
+            println!("Usage: {} URL", args.get(0));
             return;
         },
     };

--- a/src/http/headers/serialization_utils.rs
+++ b/src/http/headers/serialization_utils.rs
@@ -253,17 +253,17 @@ mod test {
     fn test_comma_split_iter() {
         // These are the same cases as in test_comma_split above.
         let s = "";
-        assert_eq!(comma_split_iter(s).collect::<~[&'static str]>(), ~[""]);
+        assert_eq!(comma_split_iter(s).collect::< Vec<&'static str> >(), vec![""]);
         let s = "foo";
-        assert_eq!(comma_split_iter(s).collect::<~[&'static str]>(), ~["foo"]);
+        assert_eq!(comma_split_iter(s).collect::< Vec<&'static str> >(), vec!["foo"]);
         let s = "foo,bar";
-        assert_eq!(comma_split_iter(s).collect::<~[&'static str]>(), ~["foo", "bar"]);
+        assert_eq!(comma_split_iter(s).collect::< Vec<&'static str> >(), vec!["foo", "bar"]);
         let s = "foo,bar,baz,quux";
-        assert_eq!(comma_split_iter(s).collect::<~[&'static str]>(), ~["foo", "bar", "baz", "quux"]);
+        assert_eq!(comma_split_iter(s).collect::< Vec<&'static str> >(), vec!["foo", "bar", "baz", "quux"]);
         let s = "\"foo,bar\",baz";
-        assert_eq!(comma_split_iter(s).collect::<~[&'static str]>(), ~["\"foo", "bar\"", "baz"]);
+        assert_eq!(comma_split_iter(s).collect::< Vec<&'static str> >(), vec!["\"foo", "bar\"", "baz"]);
         let s = " foo;q=0.8 , bar/* ";
-        assert_eq!(comma_split_iter(s).collect::<~[&'static str]>(), ~["foo;q=0.8 ", "bar/* "]);
+        assert_eq!(comma_split_iter(s).collect::< Vec<&'static str> >(), vec!["foo;q=0.8 ", "bar/* "]);
     }
 
     #[test]


### PR DESCRIPTION
- `std::os::args()` returns a Vec, which can't be indexed with [n].
- Test data was collected in a `~[T]`, but `~[T]` doesn't implement `FromIterator`. Replaced with Vec and vec![...].
