### PR TITLE
Use the new api for the tcp module

### DIFF
--- a/src/http/client/sslclients/none.rs
+++ b/src/http/client/sslclients/none.rs
@@ -24,7 +24,7 @@ impl Connecter for NetworkStream {
                 detail: None,
             })
         } else {
-            let stream = try!(TcpStream::connect(addr));
+            let stream = try!(TcpStream::connect(addr.ip.to_str(), addr.port));
             Ok(NormalStream(stream))
         }
     }

--- a/src/http/client/sslclients/openssl.rs
+++ b/src/http/client/sslclients/openssl.rs
@@ -18,7 +18,7 @@ pub enum NetworkStream {
 
 impl Connecter for NetworkStream {
     fn connect(addr: SocketAddr, _host: &str, use_ssl: bool) -> IoResult<NetworkStream> {
-        let stream = try!(TcpStream::connect(addr));
+        let stream = try!(TcpStream::connect(addr.ip.to_str(), addr.port));
         if use_ssl {
             let ssl_stream = SslStream::new(&SslContext::new(Sslv23), stream);
             Ok(SslProtectedStream(ssl_stream))

--- a/src/http/server/mod.rs
+++ b/src/http/server/mod.rs
@@ -26,7 +26,7 @@ pub trait Server: Send + Clone {
     fn serve_forever(self) {
         let config = self.get_config();
         debug!("About to bind to {:?}", config.bind_address);
-        let mut acceptor = match TcpListener::bind(config.bind_address).listen() {
+        let mut acceptor = match TcpListener::bind(config.bind_address.ip.to_str(), config.bind_address.port).listen() {
             Err(err) => {
                 error!("bind or listen failed :-(: {}", err);
                 return;


### PR DESCRIPTION
I saw the email go past, but can't find it offhand for changes to how TcpStream::connect et al work. This seems awkward, (parse the hostname, turn it into an IpAddr struct, turn it back into a string because reasons) but I couldn't find another public API to do this.
