### PR TITLE
Rust update: HashSet moved into std

### DIFF
--- a/src/codegen/main.rs
+++ b/src/codegen/main.rs
@@ -2,8 +2,6 @@
 
 #![feature(macro_rules)]
 
-extern crate collections;
-
 use std::io::{File, Truncate, Write};
 use std::os;
 

--- a/src/codegen/status.rs
+++ b/src/codegen/status.rs
@@ -7,7 +7,7 @@
 // No, I don't mind.
 // That was easy. :-)
 
-use collections::hashmap::HashSet;
+use std::collections::hashmap::HashSet;
 use std::ascii::StrAsciiExt;
 use std::io::IoResult;
 use super::get_writer;


### PR DESCRIPTION
The hashtable module from collections were moved into std.
