### PR TITLE
Add configure to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,10 @@ Getting started
 This is developed on Ubuntu and is aimed at the moving target of Rust's master
 branch.
 
+Configure the makefile::
+
+   ./configure
+
 Build everything::
 
    make all


### PR DESCRIPTION
This pull request just adds `.configure` to the Getting started section; I know it's basic, but for someone just moving into the language, it is a barrier to entry.

Instructions are already given for rust-openssl to "run its `configure` and `make`", with a reference to rust-http's `configure` - this just repeats that instruction where it is most relevant to new users.
