### PR TITLE
Rust update: ~[T] is no longer in the language.

### DIFF
--- a/src/http/memstream.rs
+++ b/src/http/memstream.rs
@@ -93,17 +93,17 @@ mod test {
     #[test]
     fn test_mem_reader_fake_stream() {
         let mut reader = MemReaderFakeStream::new(vec!(0, 1, 2, 3, 4, 5, 6, 7));
-        let mut buf = ~[];
+        let mut buf = vec![];
         assert_eq!(reader.read(buf),      Ok(0));
         assert_eq!(reader.tell(),         Ok(0));
-        let mut buf = ~[0];
+        let mut buf = vec![0];
         assert_eq!(reader.read(buf),      Ok(1));
         assert_eq!(reader.tell(),         Ok(1));
-        assert_eq!(buf,                   ~[0]);
-        let mut buf = ~[0, 0, 0, 0];
+        assert_eq!(buf,                   vec![0]);
+        let mut buf = vec![0, 0, 0, 0];
         assert_eq!(reader.read(buf),      Ok(4));
         assert_eq!(reader.tell(),         Ok(5));
-        assert_eq!(buf,                   ~[1, 2, 3, 4]);
+        assert_eq!(buf,                   vec[1, 2, 3, 4]);
         assert_eq!(reader.read(buf),      Ok(3));
         assert_eq!(buf.slice(0, 3),       &[5, 6, 7]);
         assert_eq!(reader.read(buf).ok(), None);


### PR DESCRIPTION
This replaces the last remaining ~[T]s with Vec<T>s. Compiles cleanly without errors on the latest version of Rust compiled roughly one hour ago.

Fixes #93.
