### PR TITLE
Publicize ResponseWriter fields

### DIFF
--- a/src/http/server/response.rs
+++ b/src/http/server/response.rs
@@ -20,8 +20,8 @@ use headers::transfer_encoding::Chunked;
 
 pub struct ResponseWriter<'a> {
     // The place to write to (typically a TCP stream, io::net::tcp::TcpStream)
-    writer: &'a mut BufferedStream<TcpStream>,
-    headers_written: bool,
+    pub writer: &'a mut BufferedStream<TcpStream>,
+    pub headers_written: bool,
     pub request: &'a Request,
     pub headers: Box<HeaderCollection>,
     pub status: status::Status,


### PR DESCRIPTION
Currently, `Request` and `ResponseWriter` do not `impl Clone`. As a workaround, a new `Request` can be made from the fields of an existing one, but there is no such workaround with `ResponseWriter` due to its private fields.

This PR exposes `writer` and `headers_written` so that a new `ResponseWriter` can be made from an existing `ResponseWriter` that will write to the same `BufferedStream`.

The use case for this is in extending **rust-http** to deal with multiple handlers, or a chain of handlers. Specifically, it helps to make frameworking more accessible by allowing wrapping of the `Request` and `ResponseWriter` into framework-defined structs, something that has been an issue for me.

The only thing that is actually added here is prepending the field definitions with `pub`.
