### PR TITLE
Replaced bytes! with byte literals.

### DIFF
--- a/src/codegen/read_method.rs
+++ b/src/codegen/read_method.rs
@@ -4,14 +4,14 @@ use std::io::IoResult;
 
 pub fn generate(output_dir: &Path) -> IoResult<()> {
     let mut writer = get_writer(output_dir, "read_method.rs");
-    try!(writer.write(bytes!("\
+    try!(writer.write(b"\
 // This automatically generated file is included in request.rs.
 {
     use method::{Connect, Delete, Get, Head, Options, Patch, Post, Put, Trace, ExtensionMethod};
     use server::request::MAX_METHOD_LEN;
     use rfc2616::{SP, is_token_item};
 
-")));
+"));
 
     try!(generate_branchified_method(
         writer,
@@ -32,5 +32,5 @@ pub fn generate(output_dir: &Path) -> IoResult<()> {
         "MAX_METHOD_LEN",
         "is_token_item(b)",
         "ExtensionMethod({})"));
-    writer.write(bytes!("}\n"))
+    writer.write(b"}\n")
 }


### PR DESCRIPTION
This replaces the last instances of bytes! with byte literals to silence all remaining warnings.
