### PR TITLE
The Request is moved into handle_request

### DIFF
--- a/src/examples/server/apache_fake/main.rs
+++ b/src/examples/server/apache_fake/main.rs
@@ -21,7 +21,7 @@ impl Server for ApacheFakeServer {
         Config { bind_address: SocketAddr { ip: Ipv4Addr(127, 0, 0, 1), port: 8001 } }
     }
 
-    fn handle_request(&self, _r: &Request, w: &mut ResponseWriter) {
+    fn handle_request(&self, _r: Request, w: &mut ResponseWriter) {
         w.headers.date = Some(time::now_utc());
         w.headers.server = Some(String::from_str("Apache/2.2.22 (Ubuntu)"));
         //w.headers.last_modified = Some(String::from_str("Thu, 05 May 2011 11:46:42 GMT"));

--- a/src/examples/server/hello_world/main.rs
+++ b/src/examples/server/hello_world/main.rs
@@ -19,7 +19,7 @@ impl Server for HelloWorldServer {
         Config { bind_address: SocketAddr { ip: Ipv4Addr(127, 0, 0, 1), port: 8001 } }
     }
 
-    fn handle_request(&self, _r: &Request, w: &mut ResponseWriter) {
+    fn handle_request(&self, _r: Request, w: &mut ResponseWriter) {
         w.headers.date = Some(time::now_utc());
         w.headers.content_length = Some(14);
         w.headers.content_type = Some(MediaType {

--- a/src/examples/server/info/main.rs
+++ b/src/examples/server/info/main.rs
@@ -22,7 +22,7 @@ impl Server for InfoServer {
         Config { bind_address: SocketAddr { ip: Ipv4Addr(127, 0, 0, 1), port: 8001 } }
     }
 
-    fn handle_request(&self, r: &Request, w: &mut ResponseWriter) {
+    fn handle_request(&self, r: Request, w: &mut ResponseWriter) {
         w.headers.date = Some(time::now_utc());
         w.headers.content_type = Some(MediaType {
             type_: String::from_str("text"),

--- a/src/examples/server/request_uri/main.rs
+++ b/src/examples/server/request_uri/main.rs
@@ -26,7 +26,7 @@ impl Server for RequestUriServer {
         Config { bind_address: SocketAddr { ip: Ipv4Addr(127, 0, 0, 1), port: 8001 } }
     }
 
-    fn handle_request(&self, r: &Request, w: &mut ResponseWriter) {
+    fn handle_request(&self, r: Request, w: &mut ResponseWriter) {
         w.headers.date = Some(time::now_utc());
         w.headers.server = Some(String::from_str("Rust Thingummy/0.1-pre"));
 

--- a/src/http/server/request.rs
+++ b/src/http/server/request.rs
@@ -295,11 +295,11 @@ impl fmt::Show for RequestUri {
 impl Request {
 
     /// Get a response from an open socket.
-    pub fn load(stream: &mut BufferedStream<TcpStream>) -> (Box<Request>, Result<(), status::Status>) {
+    pub fn load(stream: &mut BufferedStream<TcpStream>) -> (Request, Result<(), status::Status>) {
         let mut buffer = RequestBuffer::new(stream);
 
         // Start out with dummy values
-        let mut request = box Request {
+        let mut request = Request {
             remote_addr: buffer.stream.wrapped.peer_name().ok(),
             headers: box headers::request::HeaderCollection::new(),
             body: String::new(),

--- a/src/http/server/response.rs
+++ b/src/http/server/response.rs
@@ -2,7 +2,6 @@ use std::io::IoResult;
 use std::io::net::tcp::TcpStream;
 
 use buffer::BufferedStream;
-use server::Request;
 use status;
 use headers::response::HeaderCollection;
 use headers::content_type::MediaType;
@@ -22,18 +21,16 @@ pub struct ResponseWriter<'a> {
     // The place to write to (typically a TCP stream, io::net::tcp::TcpStream)
     writer: &'a mut BufferedStream<TcpStream>,
     headers_written: bool,
-    pub request: &'a Request,
     pub headers: Box<HeaderCollection>,
     pub status: status::Status,
 }
 
 impl<'a> ResponseWriter<'a> {
     /// Create a `ResponseWriter` writing to the specified location
-    pub fn new(writer: &'a mut BufferedStream<TcpStream>, request: &'a Request) -> ResponseWriter<'a> {
+    pub fn new(writer: &'a mut BufferedStream<TcpStream>) -> ResponseWriter<'a> {
         ResponseWriter {
             writer: writer,
             headers_written: false,
-            request: request,
             headers: box HeaderCollection::new(),
             status: status::Ok,
         }


### PR DESCRIPTION
Not including `Request` in `Response` (I don't see why it should be there) and copying `request.close_connection` allows `Request` to be moved into `handle_request`. This is useful, because it allows `Request` to be deconstructed by the server, which avoids copying of `Request` content.

Is this a desired change?
