### PR TITLE
Avoid indexing &str to be compatible with current rust master

### DIFF
--- a/src/http/server/request.rs
+++ b/src/http/server/request.rs
@@ -266,7 +266,7 @@ impl RequestUri {
     fn from_string(request_uri: String) -> Option<RequestUri> {
         if request_uri == String::from_str("*") {
             Some(Star)
-        } else if request_uri.as_slice()[0] as char == '/' {
+        } else if request_uri.as_bytes()[0] as char == '/' {
             Some(AbsolutePath(request_uri))
         } else if request_uri.as_slice().contains("/") {
             // An authority can't have a slash in it


### PR DESCRIPTION
Indexing &str has been removed from rust, instead we have to treat the
string as &[u8] using as_bytes() and index into that array.
