### PR TITLE
fix for latest rust compatibility

### DIFF
--- a/src/http/server/request.rs
+++ b/src/http/server/request.rs
@@ -268,9 +268,9 @@ impl RequestUri {
             Some(Star)
         } else if request_uri.as_bytes()[0] as char == '/' {
             Some(AbsolutePath(request_uri))
-        } else if request_uri.as_bytes().contains("/") {
+        } else if request_uri.as_slice().contains("/") {
             // An authority can't have a slash in it
-            match from_str(request_uri.as_bytes()) {
+            match from_str(request_uri.as_slice()) {
                 Some(url) => Some(AbsoluteUri(url)),
                 None => None,
             }


### PR DESCRIPTION
Or it refuses to build:

```
Could not execute process `rustc src/http/lib.rs --crate-type lib --out-dir /home/kstep/git/rusttut/adslbystat/target/deps -L /home/kstep/git/rusttut/adslbystat/target/deps -L /home/kstep/git/rusttut/adslbystat/target/deps` (status=101)
--- stderr
src/http/server/request.rs:269:19: 269:44 error: cannot index a value of type `&str`
src/http/server/request.rs:269         } else if request_uri.as_slice()[0] as char == '/' {
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
```
