### PR TITLE
Nightlies have changed to_str -> to_string

### DIFF
--- a/src/http/client/request.rs
+++ b/src/http/client/request.rs
@@ -118,7 +118,7 @@ impl<S: Reader + Writer = super::NetworkStream> RequestWriter<S> {
         };
 
         let remote_addr = try!(url_to_socket_addr(&url));
-        info!("using ip address {} for {}", remote_addr.to_str(), url.host.as_slice());
+        info!("using ip address {} for {}", remote_addr.to_string(), url.host.as_slice());
 
         fn url_to_socket_addr(url: &Url) -> IoResult<SocketAddr> {
             // Just grab the first IPv4 address
@@ -221,7 +221,7 @@ impl<S: Connecter + Reader + Writer = super::NetworkStream> RequestWriter<S> {
         // TODO: get to the point where we can say HTTP/1.1 with good conscience
         try!(write!(self.stream.get_mut_ref() as &mut Writer,
             "{} {}{}{} HTTP/1.0\r\n",
-            self.method.to_str(),
+            self.method.to_string(),
             if path.path.len()  > 0 { path.path.as_slice() } else { "/" },
             if path.query.len() > 0 { "?" } else { "" },
             url::query_to_str(&path.query)));

--- a/src/http/client/sslclients/openssl.rs
+++ b/src/http/client/sslclients/openssl.rs
@@ -18,7 +18,7 @@ pub enum NetworkStream {
 
 impl Connecter for NetworkStream {
     fn connect(addr: SocketAddr, _host: &str, use_ssl: bool) -> IoResult<NetworkStream> {
-        let stream = try!(TcpStream::connect(addr.ip.to_str().as_slice(), addr.port));
+        let stream = try!(TcpStream::connect(addr.ip.to_string().as_slice(), addr.port));
         if use_ssl {
             let ssl_stream = SslStream::new(&SslContext::new(Sslv23), stream);
             Ok(SslProtectedStream(ssl_stream))

--- a/src/http/headers/content_type.rs
+++ b/src/http/headers/content_type.rs
@@ -71,7 +71,7 @@ impl super::HeaderConvertible for MediaType {
     }
 
     fn http_value(&self) -> String {
-        self.to_str()
+        self.to_string()
     }
 }
 

--- a/src/http/headers/etag.rs
+++ b/src/http/headers/etag.rs
@@ -66,7 +66,7 @@ impl super::HeaderConvertible for EntityTag {
     }
 
     fn http_value(&self) -> String {
-        self.to_str()
+        self.to_string()
     }
 }
 

--- a/src/http/headers/host.rs
+++ b/src/http/headers/host.rs
@@ -19,7 +19,7 @@ pub struct Host {
 impl fmt::Show for Host {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.port {
-            Some(port) => write!(f, "{}:{}", self.name, port.to_str()),
+            Some(port) => write!(f, "{}:{}", self.name, port.to_string()),
             None => f.write(self.name.as_bytes()),
         }
     }
@@ -41,6 +41,6 @@ impl super::HeaderConvertible for Host {
     }
 
     fn http_value(&self) -> String {
-        self.to_str()
+        self.to_string()
     }
 }

--- a/src/http/headers/mod.rs
+++ b/src/http/headers/mod.rs
@@ -617,7 +617,7 @@ impl HeaderConvertible for uint {
     }
 
     fn http_value(&self) -> String {
-        self.to_str()
+        self.to_string()
     }
 }
 
@@ -627,7 +627,7 @@ impl HeaderConvertible for Url {
     }
 
     fn http_value(&self) -> String {
-        self.to_str()
+        self.to_string()
     }
 }
 
@@ -642,7 +642,7 @@ impl HeaderConvertible for Method {
     }
 
     fn http_value(&self) -> String {
-        self.to_str()
+        self.to_string()
     }
 }
 

--- a/src/http/server/mod.rs
+++ b/src/http/server/mod.rs
@@ -26,7 +26,7 @@ pub trait Server: Send + Clone {
     fn serve_forever(self) {
         let config = self.get_config();
         debug!("About to bind to {}", config.bind_address);
-        let mut acceptor = match TcpListener::bind(config.bind_address.ip.to_str().as_slice(), config.bind_address.port).listen() {
+        let mut acceptor = match TcpListener::bind(config.bind_address.ip.to_string().as_slice(), config.bind_address.port).listen() {
             Err(err) => {
                 error!("bind or listen failed :-(: {}", err);
                 return;

--- a/src/http/server/response.rs
+++ b/src/http/server/response.rs
@@ -72,7 +72,7 @@ impl<'a> ResponseWriter<'a> {
         // XXX: might be better not to hardcode HTTP/1.1.
         // XXX: Rust's current lack of statement-duration lifetime handling prevents this from being
         // one statement ("error: borrowed value does not live long enough")
-        let s = format!("HTTP/1.1 {}\r\n", self.status.to_str());
+        let s = format!("HTTP/1.1 {}\r\n", self.status.to_string());
         try!(self.writer.write(s.as_bytes()));
 
         // FIXME: this is not an impressive way of handling it, but so long as chunked is the only


### PR DESCRIPTION
This is with:

rustc 0.11.0-nightly (1c711db551b9a5e56ba76e002e287dcfbb2cff3c 2014-07-09 00:36:40 +0000)

I assume it's going to be a breaking change, so here it is.
