### PR TITLE
Rpath fix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,10 +5,10 @@ ifdef SSL_LIB
 else
 	SSL_CFG_AND_LIB=$(SSL_CFG)
 endif
-RUSTC ?= rustc
+RUSTC ?= rustc -C rpath
 RUSTDOC ?= rustdoc
 RUSTPKG ?= rustpkg
-RUSTFLAGS ?= -O $(SSL_CFG_AND_LIB) -C rpath
+RUSTFLAGS ?= -O $(SSL_CFG_AND_LIB)
 RUST_REPOSITORY ?= ../rust
 RUST_CTAGS ?= $(RUST_REPOSITORY)/src/etc/ctags.rust
 VERSION=0.1-pre


### PR DESCRIPTION
This commit should make rust-http pass travis (`make all check` works locally) by just re-enablng the rpath codegen option.
