### PR TITLE
Fix build for certain BSD systems

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$1" = --help ]; then
 	echo "Usage: ./configure"

--- a/prebuild
+++ b/prebuild
@@ -1,3 +1,8 @@
 ./configure
-make target/codegen src/http/generated/read_method.rs src/http/generated/status.rs
+if [ -e /usr/local/bin/gmake ]; then
+  MAKE=gmake
+else
+  MAKE=make
+fi
 
+${MAKE} target/codegen src/http/generated/read_method.rs src/http/generated/status.rs


### PR DESCRIPTION
- BSD's don't have bash in this location. /bin/sh works here perfectly.
- BSD's have GNU make as gmake. Test for it and use it accordingly.
