### PR TITLE
rust-url breaking change: Url.port is now Option<16> rather than String

### DIFF
--- a/src/http/client/request.rs
+++ b/src/http/client/request.rs
@@ -128,14 +128,7 @@ impl<S: Reader + Writer = super::NetworkStream> RequestWriter<S> {
     pub fn new_request(method: Method, url: Url, use_ssl: bool, auto_detect_ssl: bool) -> IoResult<RequestWriter<S>> {
         let host = Host {
             name: url.domain().unwrap().to_string(),
-            port: {
-                let port = url.port().unwrap();
-                if port.is_empty() {
-                    None
-                } else {
-                    Some(from_str(port).expect("You didn’t aught to give a bad port!"))
-                }
-            },
+            port: url.port(),
         };
 
         let remote_addr = try!(url_to_socket_addr(&url, &host));


### PR DESCRIPTION
https://github.com/servo/rust-url/commit/852d8a90ce6a883c01cb0fd0d99b504de7b18105
