### PR TITLE
Removed unused manifest keys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "http"
 version = "0.1.0-pre"
-readme = "README.md"
 authors = [ "Chris Morgan <me@chrismorgan.info>" ]
-tags = ["web", "http", "library"]
 build = "./prebuild.sh"
 
 [[lib]]


### PR DESCRIPTION
Cargo complains about the tags and README section being unused on builds.
This removes those sections from cargo.toml.
