### PR TITLE
Cargo has deprecated [[lib]] in favor of [lib].

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0-pre"
 authors = [ "Chris Morgan <me@chrismorgan.info>" ]
 build = "./prebuild.sh"
 
-[[lib]]
+[lib]
 name = "http"
 path = "src/http/lib.rs"
 


### PR DESCRIPTION
This avoids a deprecation warning when running cargo build.
