### PR TITLE
Fix build on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "http"
 version = "0.1.0-pre"
 authors = [ "Chris Morgan <me@chrismorgan.info>" ]
-build = "./prebuild.sh"
+build = "sh prebuild.sh"
 
 [lib]
 name = "http"


### PR DESCRIPTION
Windows doesn't like the `./` prefix, so it needs an explicit `sh file.sh` command.

Closes #140.
