### PR TITLE
Fix OpenSSL error when using HTTPS

### DIFF
--- a/src/http/client/sslclients/openssl.rs
+++ b/src/http/client/sslclients/openssl.rs
@@ -18,12 +18,12 @@ pub enum NetworkStream {
 }
 
 impl Connecter for NetworkStream {
-    fn connect(addr: SocketAddr, _host: &str, use_ssl: bool) -> IoResult<NetworkStream> {
+    fn connect(addr: SocketAddr, host: &str, use_ssl: bool) -> IoResult<NetworkStream> {
         let stream = try!(TcpStream::connect(format!("{}", addr.ip).as_slice(), addr.port));
         if use_ssl {
             let context = try!(SslContext::new(Sslv23).map_err(lift_ssl_error));
             let ssl = try!(Ssl::new(&context).map_err(lift_ssl_error));
-            ssl.set_hostname(_host);
+            ssl.set_hostname(host);
             let ssl_stream = try!(SslStream::new_from(ssl, stream).map_err(lift_ssl_error));
             Ok(SslProtectedStream(ssl_stream))
         } else {


### PR DESCRIPTION
There was an SSL handshake failure that occurred when attempting to perform an HTTP request to certain https addresses. I've been using `rust-http` in my version manager for the Rust compiler, and when I attempted to perform a HTTP GET on any Rust download the connection would fail with an OpenSSL error. (For example: `https://static.rust-lang.org/*`)

I cleaned up the error messages in `rust-openssl` to make it more clear what was happening and then diagnosed that without the SNI the request would fail. It is a very simple fix, and setting the hostname on the SSL session seemed to be enough.

The code that _was_ failing can be found here: https://github.com/jroesch/rustv/blob/master/src/rustv/version.rs#L57.
