### PR TITLE
Add #![allow(unknown_features)] for #![feature(slicing_syntax)]

### DIFF
--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -1,5 +1,6 @@
 #![crate_name = "codegen"]
 
+#![allow(unknown_features)]
 #![feature(macro_rules, slicing_syntax)]
 
 use std::io::{File, Truncate, Write};

--- a/codegen/src/status.rs
+++ b/codegen/src/status.rs
@@ -61,7 +61,7 @@ fn camel_case(msg: &str) -> String {
         // For a space, capitalise the next char
         capitalise = c == ' ';
         if !capitalise {  // And also, for a space, don't keep it
-            result.push_char(c);
+            result.push(c);
         }
     }
     result

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -10,6 +10,7 @@
 #![deny(non_camel_case_types)]
 //#[deny(missing_doc)];
 
+#![allow(unknown_features)]
 #![feature(slicing_syntax)]
 #![feature(default_type_params)]
 #![feature(macro_rules)]


### PR DESCRIPTION
`#![allow(unknown_features)]` is needed for `rustc 0.12.0-nightly (dc987adfc 2014-10-04 23:42:07 +0000)` or above to compile rust-http.
