### PR TITLE
extensions headers: multiple headers support

### DIFF
--- a/src/http/headers/mod.rs
+++ b/src/http/headers/mod.rs
@@ -889,7 +889,7 @@ macro_rules! headers_mod {
             #[deriving(Clone)]
             pub struct HeaderCollection {
                 $(pub $lower_ident: Option<$htype>,)*
-                pub extensions: TreeMap<String, String>,
+                pub extensions: TreeMap<String, Vec<String>>,
             }
 
             impl HeaderCollection {
@@ -904,7 +904,13 @@ macro_rules! headers_mod {
                 pub fn insert(&mut self, header: Header) {
                     match header {
                         $($caps_ident(value) => self.$lower_ident = Some(value),)*
-                        ExtensionHeader(key, value) => { self.extensions.insert(key, value); },
+                        ExtensionHeader(key, value) => {
+                            if self.extensions.contains_key(key) {
+                                self.extensions[key].push(value);
+                            } else {
+                                self.extensions.insert(key, vec![value]);
+                            }
+                        },
                     }
                 }
 


### PR DESCRIPTION
Hi!

I use your lib extensively, and looking forward to adapting Teepee someday. But being pragmatic, I have to live with things working now. Until recently I was satisfied with your http lib enough, but now that I need to parse cookies I stumbled upon major design flaw in your lib: no cookies support, nor multiple extension headers with the same name support.

Not that I'm complaining, you explicitly noted in README the lib is incomplete and unsupported, but as I need some ways to handle cookies, I decided to go with simplest way: add support for multiple custom header with the same name and parse cookies myself.

Hence the PR. Hope it'll help somebody out there. This is temporary measure, and I know it, but it's better than nothing.

Thanks!
