### PR TITLE
strftime now returns Result, so unwrap()

### DIFF
--- a/src/http/headers/mod.rs
+++ b/src/http/headers/mod.rs
@@ -730,7 +730,7 @@ impl HeaderConvertible for Tm {
     }
 
     fn http_value(&self) -> String {
-        self.to_utc().strftime("%a, %d %b %Y %T GMT")
+        self.to_utc().strftime("%a, %d %b %Y %T GMT").unwrap()
     }
 }
 


### PR DESCRIPTION
Recent Rust changes mean that strftime returns a Result<>, so unwrap it.
