### PR TITLE
Removed reference to debug crate from examples.

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -3,7 +3,6 @@
 #![allow(unknown_features)]
 #![feature(slicing_syntax)]
 
-extern crate debug;
 extern crate http;
 extern crate url;
 use http::client::RequestWriter;

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -4,7 +4,6 @@
 #![crate_name = "info"]
 
 extern crate time;
-extern crate debug;
 extern crate http;
 
 use std::io::net::ip::{SocketAddr, Ipv4Addr};


### PR DESCRIPTION
Removed reference to libdebug from the example files.
