### PR TITLE
change request body from String to Vec<u8> for binary request body

### DIFF
--- a/examples/info.rs
+++ b/examples/info.rs
@@ -54,7 +54,7 @@ impl Server for InfoServer {
         }
         w.write(b"</tbody></table>").unwrap();
         w.write(b"<h2>Body</h2><pre>").unwrap();
-        w.write(r.body.as_bytes()).unwrap();
+        w.write(r.body.as_slice()).unwrap();
         w.write(b"</pre>").unwrap();
 
         w.write(b"<h1>Response</h1>").unwrap();

--- a/src/http/server/request.rs
+++ b/src/http/server/request.rs
@@ -219,7 +219,7 @@ pub struct Request {
     pub headers: headers::request::HeaderCollection,
 
     /// The body of the request; empty for such methods as GET.
-    pub body: String,
+    pub body: Vec<u8>,
 
     /// The HTTP method for the request.
     pub method: Method,
@@ -309,7 +309,7 @@ impl Request {
         let mut request = Request {
             remote_addr: buffer.stream.wrapped.peer_name().ok(),
             headers: headers::request::HeaderCollection::new(),
-            body: String::new(),
+            body: Vec::new(),
             method: Options,
             request_uri: Star,
             close_connection: true,
@@ -378,10 +378,7 @@ impl Request {
         match request.headers.content_length {
             Some(length) => {
                 match buffer.read_exact(length) {
-                    Ok(body) => match String::from_utf8(body) {
-                        Ok(body_str) => request.body = body_str,
-                        Err(_) => return (request, Err(status::BadRequest))
-                    },
+                    Ok(body) => request.body = body,
                     Err(_) => return (request, Err(status::BadRequest))
                 }
             },


### PR DESCRIPTION
Trying to do to upload images from the client to the server. 

this is my html code:

``` html
    <form action="/upload" method="post" enctype="multipart/form-data">
        <input type=file name=upload_img value="" />
        <input type=submit name="sub" value=" Upload " />
    </form>
```

On uploading images 400 Bad Request always happend, because  src/http/server/request.rs line 381 String::from_utf8(body)

I think request body must be Vec< u8 >. 
What you think about this?

P.S.: sorry for my bad english.
