### PR TITLE
Convert TmFmt from strftime to String. Fixes #170

### DIFF
--- a/src/http/headers/mod.rs
+++ b/src/http/headers/mod.rs
@@ -730,7 +730,7 @@ impl HeaderConvertible for Tm {
     }
 
     fn http_value(&self) -> String {
-        self.to_utc().strftime("%a, %d %b %Y %T GMT").unwrap()
+        self.to_utc().strftime("%a, %d %b %Y %T GMT").unwrap().to_string()
     }
 }
 


### PR DESCRIPTION
Not the nicest, but it gets the job done. The whole system would probably benefit from being able to return errors, but that's for an other time.
