### PR TITLE
Use packaged openssl crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "http"
 path = "src/http/lib.rs"
 
 [dependencies.openssl]
-git = "https://github.com/sfackler/rust-openssl.git"
+version = "*"
 optional = true
 
 [dependencies.url]


### PR DESCRIPTION
Using the git reference means users can't have e.g. rust-http and rust-postgres as dependencies as rust-postgres has already changed to the packaged version. This then leads to two 'different' crates linking the [same native crate](https://github.com/rust-lang/cargo/issues/886).
