### PR TITLE
update to latest rust

### DIFF
--- a/codegen/branchify.rs
+++ b/codegen/branchify.rs
@@ -6,7 +6,7 @@ use std::io::IoResult;
 use std::iter::repeat;
 use std::ascii::AsciiExt;
 
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct ParseBranch {
     matches: Vec<u8>,
     result: Option<String>,

--- a/codegen/status.rs
+++ b/codegen/status.rs
@@ -15,13 +15,13 @@ use super::get_writer;
 
 use self::HeadingOrStatus::{Heading, Status};
 
-#[deriving(Copy)]
+#[derive(Copy)]
 enum HeadingOrStatus {
     Heading(&'static str),
     Status(HttpStatus),
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 struct HttpStatus {
     code: uint,
     reason: &'static str,
@@ -168,11 +168,12 @@ pub fn generate(output_dir: Path) -> IoResult<()> {
 pub mod status {
 use std::fmt;
 use std::ascii::AsciiExt;
+use std::num::{ToPrimitive, FromPrimitive};
 
 pub use self::Status::*;
 
 /// HTTP status code
-#[deriving(Eq, PartialEq, Clone)]
+#[derive(Eq, PartialEq, Clone)]
 pub enum Status {
 ".as_bytes()));
     for &entry in entries.iter() {

--- a/examples/apache_fake.rs
+++ b/examples/apache_fake.rs
@@ -13,7 +13,7 @@ use std::io::Writer;
 use http::server::{Config, Server, Request, ResponseWriter};
 use http::headers;
 
-#[deriving(Clone)]
+#[derive(Clone)]
 struct ApacheFakeServer;
 
 impl Server for ApacheFakeServer {

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -11,7 +11,7 @@ use std::io::Writer;
 use http::server::{Config, Server, Request, ResponseWriter};
 use http::headers::content_type::MediaType;
 
-#[deriving(Clone)]
+#[derive(Clone)]
 struct HelloWorldServer;
 
 impl Server for HelloWorldServer {

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -13,7 +13,7 @@ use http::server::{Config, Server, Request, ResponseWriter};
 use http::headers::HeaderEnum;
 use http::headers::content_type::MediaType;
 
-#[deriving(Clone)]
+#[derive(Clone)]
 struct InfoServer;
 
 impl Server for InfoServer {

--- a/examples/one_time_server.rs
+++ b/examples/one_time_server.rs
@@ -11,7 +11,7 @@ use std::io::Writer;
 use http::server::{Config, Server, Request, ResponseWriter};
 use http::headers::content_type::MediaType;
 
-#[deriving(Clone)]
+#[derive(Clone)]
 struct HelloWorldServer;
 
 impl Server for HelloWorldServer {

--- a/examples/request_uri.rs
+++ b/examples/request_uri.rs
@@ -18,7 +18,7 @@ use http::status::{BadRequest, MethodNotAllowed};
 use http::method::{Get, Head, Post, Put, Delete, Trace, Options, Connect, Patch};
 use http::headers::content_type::MediaType;
 
-#[deriving(Clone)]
+#[derive(Clone)]
 struct RequestUriServer;
 
 impl Server for RequestUriServer {

--- a/src/http/buffer.rs
+++ b/src/http/buffer.rs
@@ -60,7 +60,7 @@ impl<T: Reader> BufferedStream<T> {
     fn fill_buffer(&mut self) -> IoResult<()> {
         assert_eq!(self.read_pos, self.read_max);
         self.read_pos = 0;
-        match self.wrapped.read(self.read_buffer[mut]) {
+        match self.wrapped.read(self.read_buffer.as_mut_slice()) {
             Ok(i) => {
                 self.read_max = i;
                 Ok(())

--- a/src/http/headers/accept_ranges.rs
+++ b/src/http/headers/accept_ranges.rs
@@ -6,14 +6,14 @@ use std::ascii::AsciiExt;
 pub use self::AcceptableRanges::{RangeUnits, NoAcceptableRanges};
 pub use self::RangeUnit::{Bytes, OtherRangeUnit};
 
-#[deriving(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 // RFC 2616: range-unit = bytes-unit | other-range-unit
 pub enum RangeUnit {
     Bytes,                 // bytes-unit       = "bytes"
     OtherRangeUnit(String),  // other-range-unit = token
 }
 
-#[deriving(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 // RFC 2616: acceptable-ranges = 1#range-unit | "none"
 pub enum AcceptableRanges {
     RangeUnits(Vec<RangeUnit>),

--- a/src/http/headers/connection.rs
+++ b/src/http/headers/connection.rs
@@ -12,7 +12,7 @@ use self::Connection::{Token, Close};
 
 /// A value for the Connection header. Note that should it be a ``Token``, the string is in
 /// normalised header case (e.g. "Keep-Alive").
-#[deriving(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Connection {
     Token(String),
     Close,
@@ -20,9 +20,9 @@ pub enum Connection {
 
 impl fmt::Show for Connection {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write(match *self {
-            Token(ref s) => s.as_bytes(),
-            Close => b"close",
+        f.write_str(match *self {
+            Token(ref s) => s[],
+            Close => "close",
         })
     }
 }

--- a/src/http/headers/content_type.rs
+++ b/src/http/headers/content_type.rs
@@ -3,7 +3,7 @@ use headers::serialization_utils::{push_parameters, WriterUtil};
 use std::io::IoResult;
 use std::fmt;
 
-#[deriving(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct MediaType {
     pub type_: String,
     pub subtype: String,
@@ -32,7 +32,7 @@ impl fmt::Show for MediaType {
         //s.push_parameters(self.parameters);
         //s
         let s = format!("{}/{}", self.type_, self.subtype);
-        f.write(push_parameters(s, self.parameters[]).as_bytes())
+        f.write_str(push_parameters(s, self.parameters[])[])
     }
 }
 

--- a/src/http/headers/etag.rs
+++ b/src/http/headers/etag.rs
@@ -2,7 +2,7 @@ use headers::serialization_utils::{push_quoted_string, quoted_string, WriterUtil
 use std::io::IoResult;
 use std::fmt;
 
-#[deriving(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct EntityTag {
     pub weak: bool,
     pub opaque_tag: String,
@@ -25,9 +25,9 @@ pub fn strong_etag(opaque_tag: String) -> EntityTag {
 impl fmt::Show for EntityTag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.weak {
-            f.write(push_quoted_string(String::from_str("W/"), &self.opaque_tag).as_bytes())
+            f.write_str(push_quoted_string(String::from_str("W/"), &self.opaque_tag)[])
         } else {
-            f.write(quoted_string(&self.opaque_tag).as_bytes())
+            f.write_str(quoted_string(&self.opaque_tag)[])
         }
     }
 }

--- a/src/http/headers/host.rs
+++ b/src/http/headers/host.rs
@@ -4,7 +4,7 @@ use std::io::Reader;
 use std::fmt;
 
 /// A simple little thing for the host of a request
-#[deriving(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Host {
 
     /// The name of the host that was requested
@@ -20,7 +20,7 @@ impl fmt::Show for Host {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.port {
             Some(port) => write!(f, "{}:{}", self.name, port),
-            None => f.write(self.name.as_bytes()),
+            None => f.write_str(self.name[]),
         }
     }
 }

--- a/src/http/headers/mod.rs
+++ b/src/http/headers/mod.rs
@@ -17,7 +17,7 @@ use self::HeaderLineErr::{EndOfFile, EndOfHeaders, MalformedHeaderValue,
                           MalformedHeaderSyntax};
 use self::HeaderValueByteIteratorState::{Normal, GotLF, Finished};
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum HeaderLineErr {
     EndOfFile,
     EndOfHeaders,
@@ -72,7 +72,7 @@ pub mod transfer_encoding;
 
 pub type DeltaSeconds = u64;
 
-#[deriving(Clone, PartialEq, Eq, Copy)]
+#[derive(Clone, PartialEq, Eq, Copy)]
 pub enum ConsumeCommaLWSResult {
     CommaConsumed,
     EndOfValue,
@@ -139,7 +139,7 @@ pub fn header_enum_from_stream<R: Reader, E: HeaderEnum>(reader: &mut R)
     }
 }
 
-#[deriving(PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 enum HeaderValueByteIteratorState {
     Normal,  // Anything other than the rest.
     GotLF,  // Last character was LF (could be end of header or, if followed by SP or HT, LWS)
@@ -895,7 +895,7 @@ macro_rules! headers_mod {
             use std::io::{BufReader, IoResult};
             use std::ascii::OwnedAsciiExt;
             use time;
-            use std::collections::hash_map::{HashMap, Entries};
+            use std::collections::hash_map::{HashMap, Iter};
             use headers;
             use headers::{HeaderEnum, HeaderConvertible, HeaderValueByteIterator};
 
@@ -907,7 +907,7 @@ macro_rules! headers_mod {
                 ExtensionHeader(String, String),
             }
 
-            #[deriving(Clone)]
+            #[derive(Clone)]
             pub struct HeaderCollection {
                 $(pub $lower_ident: Option<$htype>,)*
                 pub extensions: HashMap<String, String>,
@@ -965,7 +965,7 @@ macro_rules! headers_mod {
             pub struct HeaderCollectionIterator<'a> {
                 pos: uint,
                 coll: &'a HeaderCollection,
-                ext_iter: Option<Entries<'a, String, String>>
+                ext_iter: Option<Iter<'a, String, String>>
             }
 
             impl<'a> Iterator<Header> for HeaderCollectionIterator<'a> {

--- a/src/http/headers/transfer_encoding.rs
+++ b/src/http/headers/transfer_encoding.rs
@@ -12,7 +12,7 @@ pub use self::TransferCoding::{Chunked, TransferExtension};
 ///
 /// transfer-coding         = "chunked" | transfer-extension
 /// transfer-extension      = token *( ";" parameter )
-#[deriving(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum TransferCoding {
     Chunked,
     TransferExtension(String, Vec<(String, String)>),

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -11,6 +11,7 @@
 #![feature(macro_rules)]
 #![feature(phase)]
 #![feature(globs)]
+#![feature(old_orphan_check)]
 
 #[phase(plugin, link)] extern crate log;
 extern crate url;

--- a/src/http/memstream.rs
+++ b/src/http/memstream.rs
@@ -87,18 +87,18 @@ mod test {
     fn test_mem_reader_fake_stream() {
         let mut reader = MemReaderFakeStream::new(vec!(0, 1, 2, 3, 4, 5, 6, 7));
         let mut buf = vec![];
-        assert_eq!(reader.read(buf[mut]),      Ok(0));
+        assert_eq!(reader.read(buf.as_mut_slice()),      Ok(0));
         assert_eq!(reader.tell(),              Ok(0));
         let mut buf = vec![0];
-        assert_eq!(reader.read(buf[mut]),      Ok(1));
+        assert_eq!(reader.read(buf.as_mut_slice()),      Ok(1));
         assert_eq!(reader.tell(),              Ok(1));
         assert_eq!(buf,                        vec![0]);
         let mut buf = vec![0, 0, 0, 0];
-        assert_eq!(reader.read(buf[mut]),      Ok(4));
+        assert_eq!(reader.read(buf.as_mut_slice()),      Ok(4));
         assert_eq!(reader.tell(),              Ok(5));
         assert_eq!(buf,                        vec![1, 2, 3, 4]);
-        assert_eq!(reader.read(buf[mut]),      Ok(3));
+        assert_eq!(reader.read(buf.as_mut_slice()),      Ok(3));
         assert_eq!(buf[0..3],                  [5, 6, 7][]);
-        assert_eq!(reader.read(buf[mut]).ok(), None);
+        assert_eq!(reader.read(buf.as_mut_slice()).ok(), None);
     }
 }

--- a/src/http/method.rs
+++ b/src/http/method.rs
@@ -8,7 +8,7 @@ pub use self::Method::{Options, Get, Head, Post, Put, Delete, Trace,
 /// HTTP methods, as defined in RFC 2616, §5.1.1.
 ///
 /// Method names are case-sensitive.
-#[deriving(PartialEq, Eq, Clone, Hash)]
+#[derive(PartialEq, Eq, Clone, Hash)]
 pub enum Method {
     Options,
     Get,
@@ -51,17 +51,17 @@ impl FromStr for Method {
 
 impl fmt::Show for Method {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write(match *self {
-            Options                => b"OPTIONS",
-            Get                    => b"GET",
-            Head                   => b"HEAD",
-            Post                   => b"POST",
-            Put                    => b"PUT",
-            Delete                 => b"DELETE",
-            Trace                  => b"TRACE",
-            Connect                => b"CONNECT",
-            Patch                  => b"PATCH",
-            ExtensionMethod(ref s) => s.as_bytes(),
+        f.write_str(match *self {
+            Options                => "OPTIONS",
+            Get                    => "GET",
+            Head                   => "HEAD",
+            Post                   => "POST",
+            Put                    => "PUT",
+            Delete                 => "DELETE",
+            Trace                  => "TRACE",
+            Connect                => "CONNECT",
+            Patch                  => "PATCH",
+            ExtensionMethod(ref s) => s[],
         })
     }
 }

--- a/src/http/rfc2616.rs
+++ b/src/http/rfc2616.rs
@@ -145,7 +145,7 @@ pub fn is_separator(o: u8) -> bool {
 // see https://www.iana.org/assignments/http-parameters/http-parameters.xml
 
 /// Content-coding value tokens
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum ContentCoding {
     // An encoding format produced by the file compression program "gzip" (GNU zip) as described
     // in RFC 1952 [25]. This format is a Lempel-Ziv coding (LZ77) with a 32 bit CRC.
@@ -178,11 +178,11 @@ pub enum ContentCoding {
 
 impl fmt::Show for ContentCoding {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write(match *self {
-            ContentCoding::Gzip => b"gzip",
-            ContentCoding::Compress => b"compress",
-            ContentCoding::Deflate => b"deflate",
-            ContentCoding::Identity => b"identity",
+        f.write_str(match *self {
+            ContentCoding::Gzip => "gzip",
+            ContentCoding::Compress => "compress",
+            ContentCoding::Deflate => "deflate",
+            ContentCoding::Identity => "identity",
         })
     }
 }
@@ -206,7 +206,7 @@ impl FromStr for ContentCoding {
 /// Transfer-coding value tokens
 // Identity is in RFC 2616 but is withdrawn in RFC 2616 errata ID 408
 // http://www.rfc-editor.org/errata_search.php?rfc=2616&eid=408
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum TransferCoding {
     Chunked,   // RFC 2616, §3.6.1
     Gzip,      // See above
@@ -216,11 +216,11 @@ pub enum TransferCoding {
 
 impl fmt::Show for TransferCoding {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write(match *self {
-            TransferCoding::Chunked => b"chunked",
-            TransferCoding::Gzip => b"gzip",
-            TransferCoding::Compress => b"compress",
-            TransferCoding::Deflate => b"deflate",
+        f.write_str(match *self {
+            TransferCoding::Chunked => "chunked",
+            TransferCoding::Gzip => "gzip",
+            TransferCoding::Compress => "compress",
+            TransferCoding::Deflate => "deflate",
         })
     }
 }

--- a/src/http/server/request.rs
+++ b/src/http/server/request.rs
@@ -243,7 +243,7 @@ pub struct Request {
 }
 
 /// The URI (Request-URI in RFC 2616) as specified in the Status-Line of an HTTP request
-#[deriving(PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub enum RequestUri {
     /// 'The asterisk "*" means that the request does not apply to a particular resource, but to the
     /// server itself, and is only allowed when the method used does not necessarily apply to a
@@ -297,10 +297,10 @@ impl RequestUri {
 impl fmt::Show for RequestUri {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Star => f.write(b"*"),
+            Star => f.write_str("*"),
             AbsoluteUri(ref url) => url.fmt(f),
-            AbsolutePath(ref str) => f.write(str.as_bytes()),
-            Authority(ref str) => f.write(str.as_bytes()),
+            AbsolutePath(ref s) => f.write_str(s[]),
+            Authority(ref s) => f.write_str(s[]),
         }
     }
 }


### PR DESCRIPTION
  * #[deriving] -> #[derive]
  * ToPrimitive/FromPrimitive not in prelude
  * [mut] syntax doesn't work to provide mut slice
  * Formatter::write() -> Formatter::write_str()
  * hash_map::Entries -> hash_map::Iter
  * #![feature(old_orphan_check)]
  * channel/Sender/Receiver not in prelude and return Result